### PR TITLE
Fixed timeouts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,16 +14,15 @@ include(GNUInstallDirs)
 file(GLOB_RECURSE UVENT_HEADERS include/*.h include/*.hpp)
 file(GLOB_RECURSE UVENT_SOURCES src/*.cpp src/*.c)
 
-foreach(header ${UVENT_HEADERS})
+foreach (header ${UVENT_HEADERS})
     if (header MATCHES "${CMAKE_BINARY_DIR}")
         list(REMOVE_ITEM UVENT_HEADERS ${header})
-    endif()
-endforeach()
+    endif ()
+endforeach ()
 
 if (CMAKE_BUILD_TYPE STREQUAL "Debug")
     message(STATUS "Debug mode enabled")
-    add_definitions(-DUVENT_DEBUG)
-
+    #    add_definitions(-DUVENT_DEBUG)
     # include(FetchContent)
     # FetchContent_Declare(
     #         spdlog
@@ -39,41 +38,44 @@ add_library(uvent ${UVENT_SOURCES})
 add_library(usub::uvent ALIAS uvent)
 
 configure_package_config_file(
-    cmake/uventConfig.cmake.in
-    ${CMAKE_CURRENT_BINARY_DIR}/uventConfig.cmake
-    INSTALL_DESTINATION lib/cmake/uvent
+        cmake/uventConfig.cmake.in
+        ${CMAKE_CURRENT_BINARY_DIR}/uventConfig.cmake
+        INSTALL_DESTINATION lib/cmake/uvent
 )
 
 install(TARGETS uvent
-    EXPORT uventTargets
-    #LIBRARY DESTINATION lib
-    #ARCHIVE DESTINATION lib
-    #RUNTIME DESTINATION bin
-    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/uvent
-    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/uvent
+        EXPORT uventTargets
+        #LIBRARY DESTINATION lib
+        #ARCHIVE DESTINATION lib
+        #RUNTIME DESTINATION bin
+        PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/uvent
+        INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/uvent
 )
 
-target_include_directories(uvent 
-PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}/include
-PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
-    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/uvent>
+target_include_directories(uvent
+        PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+        PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/uvent>
 )
 
-foreach(header ${UVENT_HEADERS})
+foreach (header ${UVENT_HEADERS})
     get_filename_component(header_path ${header} DIRECTORY)
     file(RELATIVE_PATH header_relative_path "${CMAKE_CURRENT_SOURCE_DIR}/include" ${header_path})
     install(FILES ${header} DESTINATION include/server/${header_relative_path})
-endforeach()
+endforeach ()
 
 install(EXPORT uventTargets
-    FILE uventConfig.cmake
-    NAMESPACE usub::
-    DESTINATION lib/cmake/uvent
+        FILE uventConfig.cmake
+        NAMESPACE usub::
+        DESTINATION lib/cmake/uvent
 )
 
-if(BUILD_MAIN)
+if (BUILD_MAIN)
+    add_compile_options(-fsanitize=address)
+    add_link_options(-fsanitize=address)
+
     add_executable(uvent_exe examples/main.cpp)
-    target_link_libraries(uvent_exe usub::uvent)
-endif()
+    target_link_libraries(uvent_exe PRIVATE usub::uvent)
+endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,7 @@ install(EXPORT uventTargets
 )
 
 option(BUILD_MAIN "Buld main executable for testing" OFF)
+option(ENABLE_SANITIZERS "Buld main executable for testing" OFF)
 
 if (BUILD_MAIN)
     if (CMAKE_BUILD_TYPE STREQUAL "Debug")
@@ -72,16 +73,70 @@ if (BUILD_MAIN)
         FetchContent_MakeAvailable(spdlog)
     endif ()
 
-    add_compile_options(-fsanitize=address)
-    add_link_options(-fsanitize=address)
+    if (ENABLE_SANITIZERS)
+        add_executable(uvent_asan_ubsan ${UVENT_SOURCES} examples/main.cpp)
+        target_compile_definitions(uvent_asan_ubsan PRIVATE
+                $<$<CONFIG:Debug>:UVENT_DEBUG>
+        )
+        target_include_directories(uvent_asan_ubsan
+                PRIVATE
+                ${CMAKE_CURRENT_SOURCE_DIR}/include
+        )
+        target_link_libraries(uvent_asan_ubsan PRIVATE $<$<CONFIG:Debug>:spdlog::spdlog>)
+        target_compile_options(uvent_asan_ubsan PRIVATE
+                -fsanitize=address,undefined
+                -fno-sanitize-recover=all
+                -fno-omit-frame-pointer
+                -g
+        )
+        target_link_options(uvent_asan_ubsan PRIVATE
+                -fsanitize=address,undefined
+        )
+
+        add_executable(uvent_tsan ${UVENT_SOURCES} examples/main.cpp)
+        target_compile_definitions(uvent_tsan PRIVATE
+                $<$<CONFIG:Debug>:UVENT_DEBUG>
+        )
+        target_include_directories(uvent_tsan
+                PRIVATE
+                ${CMAKE_CURRENT_SOURCE_DIR}/include
+        )
+        target_link_libraries(uvent_tsan PRIVATE $<$<CONFIG:Debug>:spdlog::spdlog>)
+        target_compile_options(uvent_tsan PRIVATE -fsanitize=thread -g)
+        target_link_options(uvent_tsan PRIVATE -fsanitize=thread)
+
+
+        if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+            add_executable(uvent_msan_ubsan ${UVENT_SOURCES} examples/main.cpp)
+            target_compile_definitions(uvent_msan_ubsan PRIVATE
+                    $<$<CONFIG:Debug>:UVENT_DEBUG>
+            )
+            target_include_directories(uvent_msan_ubsan
+                    PRIVATE
+                    ${CMAKE_CURRENT_SOURCE_DIR}/include
+            )
+            target_link_libraries(uvent_msan_ubsan PRIVATE $<$<CONFIG:Debug>:spdlog::spdlog>)
+            target_compile_options(uvent_msan_ubsan PRIVATE
+                    -fsanitize=memory,undefined
+                    -fsanitize-memory-track-origins=2
+                    -fno-sanitize-recover=all
+                    -fno-omit-frame-pointer
+                    -g
+            )
+            target_link_options(uvent_msan_ubsan PRIVATE
+                    -fsanitize=memory,undefined
+            )
+        endif()
+    endif()
 
     add_executable(uvent_exe ${UVENT_SOURCES} examples/main.cpp)
     target_compile_definitions(uvent_exe PRIVATE
-        $<$<CONFIG:Debug>:UVENT_DEBUG>
+            $<$<CONFIG:Debug>:UVENT_DEBUG>
     )
     target_include_directories(uvent_exe
-        PRIVATE
-        ${CMAKE_CURRENT_SOURCE_DIR}/include
-     )
-    target_link_libraries(uvent_exe PRIVATE $<$<CONFIG:Debug>:spdlog::spdlog>) 
+            PRIVATE
+            ${CMAKE_CURRENT_SOURCE_DIR}/include
+    )
+    target_link_libraries(uvent_exe PRIVATE $<$<CONFIG:Debug>:spdlog::spdlog>)
+
 endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,8 +6,6 @@ set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_FLAGS_DEBUG "-g -O0 -rdynamic -fPIC" CACHE STRING "Debug flags" FORCE)
 set(CMAKE_C_FLAGS_DEBUG "-g -O0 -rdynamic -fPIC" CACHE STRING "Debug flags" FORCE)
 
-include_directories(${uvent_SOURCE_DIR})
-
 include(CMakePackageConfigHelpers)
 include(GNUInstallDirs)
 
@@ -19,18 +17,6 @@ foreach (header ${UVENT_HEADERS})
         list(REMOVE_ITEM UVENT_HEADERS ${header})
     endif ()
 endforeach ()
-
-if (CMAKE_BUILD_TYPE STREQUAL "Debug")
-    message(STATUS "Debug mode enabled")
-    #    add_definitions(-DUVENT_DEBUG)
-    # include(FetchContent)
-    # FetchContent_Declare(
-    #         spdlog
-    #         GIT_REPOSITORY https://github.com/gabime/spdlog.git
-    #         GIT_TAG v1.14.1
-    # )
-    # FetchContent_MakeAvailable(spdlog)
-endif ()
 
 add_definitions(-DUVENT_PIN_THREDS)
 
@@ -56,7 +42,7 @@ target_include_directories(uvent
         PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/include
         PUBLIC
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
         $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/uvent>
 )
 
@@ -72,10 +58,30 @@ install(EXPORT uventTargets
         DESTINATION lib/cmake/uvent
 )
 
+option(BUILD_MAIN "Buld main executable for testing" OFF)
+
 if (BUILD_MAIN)
+    if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+        message(STATUS "Debug mode enabled")
+        include(FetchContent)
+        FetchContent_Declare(
+                spdlog
+                GIT_REPOSITORY https://github.com/gabime/spdlog.git
+                GIT_TAG v1.14.1
+        )
+        FetchContent_MakeAvailable(spdlog)
+    endif ()
+
     add_compile_options(-fsanitize=address)
     add_link_options(-fsanitize=address)
 
-    add_executable(uvent_exe examples/main.cpp)
-    target_link_libraries(uvent_exe PRIVATE usub::uvent)
+    add_executable(uvent_exe ${UVENT_SOURCES} examples/main.cpp)
+    target_compile_definitions(uvent_exe PRIVATE
+        $<$<CONFIG:Debug>:UVENT_DEBUG>
+    )
+    target_include_directories(uvent_exe
+        PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+     )
+    target_link_libraries(uvent_exe PRIVATE $<$<CONFIG:Debug>:spdlog::spdlog>) 
 endif ()

--- a/examples/main.cpp
+++ b/examples/main.cpp
@@ -1,7 +1,7 @@
-#include "include/uvent/Uvent.h"
-#include "include/uvent/tasks/AwaitableFrame.h"
-#include "include/uvent/system/SystemContext.h"
-#include "include/uvent/net/Socket.h"
+#include "uvent/Uvent.h"
+#include "uvent/tasks/AwaitableFrame.h"
+#include "uvent/system/SystemContext.h"
+#include "uvent/net/Socket.h"
 
 using namespace usub::uvent;
 

--- a/examples/main.cpp
+++ b/examples/main.cpp
@@ -85,7 +85,7 @@ task::Awaitable<void> sendingCoro() {
 }
 
 int main() {
-    settings::timeout_duration_ms = 20000;
+    settings::timeout_duration_ms = 5000;
 #ifdef UVENT_DEBUG
     spdlog::set_pattern("[%Y-%m-%d %H:%M:%S.%e] [thread %t] [%l] %v%$");
     spdlog::set_level(spdlog::level::trace);

--- a/examples/main.cpp
+++ b/examples/main.cpp
@@ -1,7 +1,7 @@
-#include "include/uvent/Uvent.h"
-#include "include/uvent/tasks/AwaitableFrame.h"
-#include "include/uvent/system/SystemContext.h"
-#include "include/uvent/net/Socket.h"
+#include "uvent/Uvent.h"
+#include "uvent/tasks/AwaitableFrame.h"
+#include "uvent/system/SystemContext.h"
+#include "uvent/net/Socket.h"
 
 using namespace usub::uvent;
 
@@ -37,18 +37,17 @@ task::Awaitable<void> clientCoro(net::TCPClientSocket socket) {
                 const_cast<uint8_t *>(reinterpret_cast<const uint8_t *>(httpResponse.data())),
                 httpResponse.size()
         );
-        socket.update_timeout(20000);
+#ifdef UVENT_DEBUG
+        spdlog::warn("Write size: {}", wrsz);
+#endif
         if (wrsz <= 0) {
             break;
         }
-#ifdef UVENT_DEBUG
-        spdlog::info("Write size: {}", wrsz);
-#endif
+        socket.update_timeout(20000);
     }
 #ifdef UVENT_DEBUG
     spdlog::warn("client_coro finished");
 #endif
-    std::cout << "finished client coro\n";
     co_return;
 }
 

--- a/examples/main.cpp
+++ b/examples/main.cpp
@@ -16,10 +16,12 @@ task::Awaitable<void> clientCoro(net::TCPClientSocket socket) {
             "Content-Length: 20\r\n"
             "\r\n"
             "{\"status\":\"success\"}";
+
+    socket.set_timeout_ms(5000);
     while (true) {
         buffer.clear();
         ssize_t rdsz = co_await socket.async_read(buffer, max_read_size);
-        socket.update_timeout(20000);
+        socket.update_timeout(5000);
 #ifdef UVENT_DEBUG
         spdlog::info("Read size: {}", rdsz);
         std::string s(buffer.data(), buffer.data() + buffer.size());
@@ -43,7 +45,7 @@ task::Awaitable<void> clientCoro(net::TCPClientSocket socket) {
         if (wrsz <= 0) {
             break;
         }
-        socket.update_timeout(20000);
+        socket.update_timeout(5000);
     }
 #ifdef UVENT_DEBUG
     spdlog::warn("client_coro finished");

--- a/examples/main.cpp
+++ b/examples/main.cpp
@@ -48,6 +48,7 @@ task::Awaitable<void> clientCoro(net::TCPClientSocket socket) {
 #ifdef UVENT_DEBUG
     spdlog::warn("client_coro finished");
 #endif
+    std::cout << "finished client coro\n";
     co_return;
 }
 
@@ -84,7 +85,7 @@ task::Awaitable<void> sendingCoro() {
 }
 
 int main() {
-    settings::timeout_duration_ms = 5000;
+    settings::timeout_duration_ms = 20000;
 #ifdef UVENT_DEBUG
     spdlog::set_pattern("[%Y-%m-%d %H:%M:%S.%e] [thread %t] [%l] %v%$");
     spdlog::set_level(spdlog::level::trace);

--- a/include/uvent/Uvent.h
+++ b/include/uvent/Uvent.h
@@ -6,7 +6,7 @@
 #define UVENT_UVENT_H
 
 #include <cmath>
-#include "include/uvent/pool/ThreadPool.h"
+#include "uvent/pool/ThreadPool.h"
 
 namespace usub {
     class Uvent : std::enable_shared_from_this<Uvent> {

--- a/include/uvent/Uvent.h
+++ b/include/uvent/Uvent.h
@@ -6,7 +6,9 @@
 #define UVENT_UVENT_H
 
 #include <cmath>
+#include "uvent/net/Socket.h"
 #include "uvent/pool/ThreadPool.h"
+#include "uvent/system/SystemContext.h"
 
 namespace usub {
     class Uvent : std::enable_shared_from_this<Uvent> {

--- a/include/uvent/base/Predefines.h
+++ b/include/uvent/base/Predefines.h
@@ -41,6 +41,10 @@ namespace usub
             template <typename>
             class AwaitableIOFrame;
         }
+        namespace utils
+        {
+            class TimerWheel;
+        }
     }
 }
 

--- a/include/uvent/net/AwaiterOperations.h
+++ b/include/uvent/net/AwaiterOperations.h
@@ -6,7 +6,7 @@
 #define AWAITEROPERATIONS_H
 
 #include "SocketMetadata.h"
-#include "include/uvent/tasks/AwaitableFrame.h"
+#include "uvent/tasks/AwaitableFrame.h"
 
 namespace usub::uvent::net::detail
 {

--- a/include/uvent/net/Socket.h
+++ b/include/uvent/net/Socket.h
@@ -9,13 +9,13 @@
 #include <expected>
 #include "SocketMetadata.h"
 #include "AwaiterOperations.h"
-#include "include/uvent/system/SystemContext.h"
-#include "include/uvent/utils/buffer/DynamicBuffer.h"
-#include "include/uvent/utils/errors/IOErrors.h"
-#include "include/uvent/system/Defines.h"
-#include "include/uvent/utils/net/net.h"
-#include "include/uvent/utils/net/socket.h"
-#include "include/uvent/base/Predefines.h"
+#include "uvent/system/SystemContext.h"
+#include "uvent/utils/buffer/DynamicBuffer.h"
+#include "uvent/utils/errors/IOErrors.h"
+#include "uvent/system/Defines.h"
+#include "uvent/utils/net/net.h"
+#include "uvent/utils/net/socket.h"
+#include "uvent/base/Predefines.h"
 
 namespace usub::uvent::net
 {

--- a/include/uvent/net/SocketMetadata.h
+++ b/include/uvent/net/SocketMetadata.h
@@ -118,6 +118,11 @@ namespace usub::uvent::net
         }
     };
 
+    static void delete_header(void* ptr)
+    {
+        delete static_cast<SocketHeader*>(ptr);
+    }
+
     template <Proto p, Role r>
     class Socket;
 

--- a/include/uvent/net/SocketMetadata.h
+++ b/include/uvent/net/SocketMetadata.h
@@ -7,6 +7,7 @@
 
 #include <coroutine>
 #include <atomic>
+#include <iostream>
 
 #include "include/uvent/utils/sync/RefCountedSession.h"
 #include "include/uvent/utils/intrinsincs/optimizations.h"
@@ -17,7 +18,7 @@ namespace usub::uvent::net
 
     enum class Role : uint8_t { PASSIVE = 1 << 2, ACTIVE = 1 << 3 };
 
-    enum class AdditionalState : uint8_t { CONNECTION_PENDING = 1 << 4, CONNECTION_FAILED = 1 << 5 };
+    enum class AdditionalState : uint8_t { CONNECTION_PENDING = 1 << 4, CONNECTION_FAILED = 1 << 5, DISCONNECTED = 1 << 6};
 
     struct alignas(32) SocketHeader
     {
@@ -26,6 +27,11 @@ namespace usub::uvent::net
         uint8_t socket_info;
         std::coroutine_handle<> first, second;
         std::atomic<uint64_t> state;
+
+        ~SocketHeader()
+        {
+            std::cout << "Deleted socket header\n";
+        }
 
         __attribute__((always_inline)) void close_for_new_refs() noexcept
         {
@@ -116,6 +122,39 @@ namespace usub::uvent::net
             using namespace usub::utils::sync::refc;
             return (this->state.load(std::memory_order_acquire) & WRITING_MASK) != 0;
         }
+
+        __attribute__((always_inline)) void mark_disconnected() noexcept
+        {
+            using namespace usub::utils::sync::refc;
+            this->state.fetch_or(DISCONNECTED_MASK, std::memory_order_release);
+        }
+
+        [[nodiscard]] __attribute__((always_inline)) bool is_disconnected_now() const noexcept
+        {
+            using namespace usub::utils::sync::refc;
+            return (this->state.load(std::memory_order_acquire) & DISCONNECTED_MASK) != 0;
+        }
+
+        __attribute__((always_inline)) uint64_t timeout_epoch_snapshot(uint64_t s) noexcept {
+            using namespace usub::utils::sync::refc;
+            return (s & TIMEOUT_EPOCH_MASK);
+        }
+
+        __attribute__((always_inline)) uint64_t timeout_epoch_load(const std::atomic<uint64_t>& st) noexcept {
+            using namespace usub::utils::sync::refc;
+            return (st.load(std::memory_order_acquire) & TIMEOUT_EPOCH_MASK);
+        }
+
+        __attribute__((always_inline)) void timeout_epoch_bump(std::atomic<uint64_t>& st) noexcept {
+            using namespace usub::utils::sync::refc;
+            st.fetch_add(TIMEOUT_EPOCH_BUMP, std::memory_order_acq_rel);
+        }
+
+        __attribute__((always_inline)) bool timeout_epoch_changed(const std::atomic<uint64_t>& st, uint64_t snap) noexcept {
+            using namespace usub::utils::sync::refc;
+            return (st.load(std::memory_order_acquire) & TIMEOUT_EPOCH_MASK) != snap;
+        }
+
     };
 
     static void delete_header(void* ptr)

--- a/include/uvent/net/SocketMetadata.h
+++ b/include/uvent/net/SocketMetadata.h
@@ -8,7 +8,11 @@
 #include <coroutine>
 #include <atomic>
 
+#if UVENT_DEBUG
 #include "spdlog/spdlog.h"
+#endif
+
+#include "uvent/base/Predefines.h"
 #include "uvent/utils/sync/RefCountedSession.h"
 #include "uvent/utils/intrinsincs/optimizations.h"
 
@@ -168,6 +172,18 @@ namespace usub::uvent::net
         {
             using namespace usub::utils::sync::refc;
             return (this->state.load(std::memory_order_acquire) & TIMEOUT_EPOCH_MASK) != snap;
+        }
+
+        [[nodiscard]] __attribute__((always_inline)) bool is_done_client_coroutine_with_timeout() const
+        {
+            using namespace usub::utils::sync::refc;
+            return (this->state.load(std::memory_order_acquire) & COUNT_MASK) == 1;
+        }
+
+        [[nodiscard]] __attribute__((always_inline)) uint64_t get_counter() const
+        {
+            using namespace usub::utils::sync::refc;
+            return (this->state.load(std::memory_order_acquire) & COUNT_MASK);
         }
 
         [[nodiscard]] __attribute__((always_inline)) bool is_tcp() const

--- a/include/uvent/net/SocketMetadata.h
+++ b/include/uvent/net/SocketMetadata.h
@@ -8,8 +8,8 @@
 #include <coroutine>
 #include <atomic>
 
-#include "include/uvent/utils/sync/RefCountedSession.h"
-#include "include/uvent/utils/intrinsincs/optimizations.h"
+#include "uvent/utils/sync/RefCountedSession.h"
+#include "uvent/utils/intrinsincs/optimizations.h"
 
 namespace usub::uvent::net
 {

--- a/include/uvent/net/SocketMetadata.h
+++ b/include/uvent/net/SocketMetadata.h
@@ -7,7 +7,6 @@
 
 #include <coroutine>
 #include <atomic>
-#include <iostream>
 
 #include "include/uvent/utils/sync/RefCountedSession.h"
 #include "include/uvent/utils/intrinsincs/optimizations.h"
@@ -27,11 +26,6 @@ namespace usub::uvent::net
         uint8_t socket_info;
         std::coroutine_handle<> first, second;
         std::atomic<uint64_t> state;
-
-        ~SocketHeader()
-        {
-            std::cout << "Deleted socket header\n";
-        }
 
         __attribute__((always_inline)) void close_for_new_refs() noexcept
         {

--- a/include/uvent/poll/EPoller.h
+++ b/include/uvent/poll/EPoller.h
@@ -22,11 +22,11 @@ namespace usub::uvent::core {
 
         ~EPoller() override = default;
 
-        void addEvent(net::SocketHeader *socket, OperationType initialState) override;
+        void addEvent(net::SocketHeader *header, OperationType initialState) override;
 
-        void updateEvent(net::SocketHeader *socket, OperationType initialState) override;
+        void updateEvent(net::SocketHeader *header, OperationType initialState) override;
 
-        void removeEvent(int fd, uint64_t timerId, OperationType op) override;
+        void removeEvent(net::SocketHeader* header, OperationType op) override;
 
         bool poll(int timeout) override;
 

--- a/include/uvent/poll/EPoller.h
+++ b/include/uvent/poll/EPoller.h
@@ -8,9 +8,9 @@
 #include <mutex>
 #include <csignal>
 #include <utility>
-#include "include/uvent/utils/timer/TimerWheel.h"
+#include "uvent/utils/timer/TimerWheel.h"
 #include "PollerBase.h"
-#include "include/uvent/tasks/AwaitableFrame.h"
+#include "uvent/tasks/AwaitableFrame.h"
 
 namespace usub::uvent::core {
     /**

--- a/include/uvent/poll/KPoller.h
+++ b/include/uvent/poll/KPoller.h
@@ -7,7 +7,7 @@
 
 #if 0
 #include <mutex>
-#include "include/uvent/poll/PollerBase.h"
+#include "uvent/poll/PollerBase.h"
 
 namespace usub::uvent::core {
     /**

--- a/include/uvent/poll/PollerBase.h
+++ b/include/uvent/poll/PollerBase.h
@@ -7,7 +7,7 @@
 
 #include <memory>
 #include <semaphore>
-#include "include/uvent/net/SocketMetadata.h"
+#include "uvent/net/SocketMetadata.h"
 
 namespace usub::uvent::core
 {

--- a/include/uvent/poll/PollerBase.h
+++ b/include/uvent/poll/PollerBase.h
@@ -27,7 +27,7 @@ namespace usub::uvent::core
     class PollerBase
     {
     public:
-        explicit PollerBase(uint64_t timeoutDuration_ms);
+        explicit PollerBase();
 
         virtual ~PollerBase() = default;
 
@@ -36,7 +36,7 @@ namespace usub::uvent::core
         virtual void updateEvent(net::SocketHeader* socket, OperationType initialState) = 0;
 
         virtual void
-        removeEvent(int fd, uint64_t timerId, OperationType op) = 0;
+        removeEvent(net::SocketHeader* header, OperationType op) = 0;
 
         virtual bool poll(int timeout) = 0;
 

--- a/include/uvent/poll/PollerBase.h
+++ b/include/uvent/poll/PollerBase.h
@@ -46,6 +46,8 @@ namespace usub::uvent::core
 
         virtual void lock_poll(int timeout) = 0;
 
+        int get_poll_fd();
+
     public:
         std::binary_semaphore lock{1};
 

--- a/include/uvent/pool/ThreadPool.h
+++ b/include/uvent/pool/ThreadPool.h
@@ -6,8 +6,8 @@
 #define UVENT_THREADPOOL_H
 
 #include <cmath>
-#include "include/uvent/system/Thread.h"
-#include "include/uvent/system/Defines.h"
+#include "uvent/system/Thread.h"
+#include "uvent/system/Defines.h"
 
 namespace usub::uvent
 {

--- a/include/uvent/system/SystemContext.h
+++ b/include/uvent/system/SystemContext.h
@@ -59,11 +59,42 @@ namespace usub::uvent::system
         }
     }
 
+    /**
+     * @brief Spawns a coroutine for execution in the global thread context.
+     *
+     * Retrieves the coroutine promise from the given function object and, if valid,
+     * enqueues its coroutine handle into the global task queue.
+     *
+     * @tparam F Coroutine function type providing `get_promise()`.
+     * @param f Coroutine function to be spawned.
+     *
+     * @warning Method doesn't check if the coroutine is valid beyond `get_promise()`.
+     *          Ensure the coroutine object remains valid until scheduled.
+     */
     template <typename F>
     void co_spawn(F&& f)
     {
         auto promise = f.get_promise();
-        if (promise) system::this_thread::detail::st->enqueue(promise->get_coroutine_handle());
+        if (promise) this_thread::detail::st->enqueue(promise->get_coroutine_handle());
+    }
+
+    /**
+     * @brief Schedules a timer in timer wheel.
+     *
+     * Adds the given timer instance into timer wheel handler,
+     * allowing it to be triggered after its configured expiry.
+     *
+     * @param timer Pointer to a valid timer object.
+     *
+     * @note If the timer type is set to TIMEOUT, it will fire once;
+     *       otherwise, it will repeat indefinitely.
+     *
+     * @warning This method does not check whether the timer is initialized
+     *          or already active. Use only with properly constructed and inactive timers.
+     */
+    inline void spawn_timer(utils::Timer* timer)
+    {
+        this_thread::detail::wh->addTimer(timer);
     }
 }
 

--- a/include/uvent/system/SystemContext.h
+++ b/include/uvent/system/SystemContext.h
@@ -7,14 +7,14 @@
 
 #include <chrono>
 #include <memory>
-#include "include/uvent/tasks/SharedTasks.h"
-#include "include/uvent/utils/timer/TimerWheel.h"
+#include "uvent/tasks/SharedTasks.h"
+#include "uvent/utils/timer/TimerWheel.h"
 #include "Settings.h"
-#include "include/uvent/utils/datastructures/queue/FastQueue.h"
-#include "include/uvent/utils/datastructures/queue/ConcurrentQueues.h"
-#include "include/uvent/utils/sync/QSBR.h"
-#include "include/uvent/poll/PollerBase.h"
-#include "include/uvent/base/Predefines.h"
+#include "uvent/utils/datastructures/queue/FastQueue.h"
+#include "uvent/utils/datastructures/queue/ConcurrentQueues.h"
+#include "uvent/utils/sync/QSBR.h"
+#include "uvent/poll/PollerBase.h"
+#include "uvent/base/Predefines.h"
 
 namespace usub::uvent::system
 {

--- a/include/uvent/system/Thread.h
+++ b/include/uvent/system/Thread.h
@@ -10,11 +10,11 @@
 #include <chrono>
 #include <barrier>
 #include <functional>
-#include "include/uvent/system/Defines.h"
-#include "include/uvent/utils/thread/ThreadStats.h"
-#include "include/uvent/utils/timer/HighPerfomanceTimer.h"
-#include "include/uvent/system/SystemContext.h"
-#include "include/uvent/base/Predefines.h"
+#include "uvent/system/Defines.h"
+#include "uvent/utils/thread/ThreadStats.h"
+#include "uvent/utils/timer/HighPerfomanceTimer.h"
+#include "uvent/system/SystemContext.h"
+#include "uvent/base/Predefines.h"
 
 namespace usub::uvent::system
 {

--- a/include/uvent/tasks/Awaitable.h
+++ b/include/uvent/tasks/Awaitable.h
@@ -10,7 +10,7 @@
 #include <iostream>
 #include <coroutine>
 #include <exception>
-#include "include/uvent/base/Predefines.h"
+#include "uvent/base/Predefines.h"
 
 #ifdef UVENT_DEBUG
 

--- a/include/uvent/tasks/AwaitableFrame.h
+++ b/include/uvent/tasks/AwaitableFrame.h
@@ -10,8 +10,8 @@
 #include <ranges>
 
 #include "Awaitable.h"
-#include "include/uvent/utils/datastructures/queue/FastQueue.h"
-#include "include/uvent/base/Predefines.h"
+#include "uvent/utils/datastructures/queue/FastQueue.h"
+#include "uvent/base/Predefines.h"
 
 namespace usub::uvent {
     namespace detail {

--- a/include/uvent/tasks/SharedTasks.h
+++ b/include/uvent/tasks/SharedTasks.h
@@ -8,7 +8,7 @@
 #include <mutex>
 #include <memory>
 #include "Awaitable.h"
-#include "include/uvent/utils/datastructures/queue/ConcurrentQueues.h"
+#include "uvent/utils/datastructures/queue/ConcurrentQueues.h"
 
 namespace usub::uvent::task {
     class SharedTasks {

--- a/include/uvent/utils/datastructures/queue/ConcurrentQueues.h
+++ b/include/uvent/utils/datastructures/queue/ConcurrentQueues.h
@@ -12,9 +12,9 @@
 #include <type_traits>
 #include <cassert>
 #include <cstring>
-#include "include/uvent/utils/intrinsincs/optimizations.h"
-#include "include/uvent/system/Settings.h"
-#include "include/uvent/utils/datastructures/DataStructuresMetadata.h"
+#include "uvent/utils/intrinsincs/optimizations.h"
+#include "uvent/system/Settings.h"
+#include "uvent/utils/datastructures/DataStructuresMetadata.h"
 
 // ======== helpers ========
 namespace usub::queue::concurrent

--- a/include/uvent/utils/datastructures/queue/FastQueue.h
+++ b/include/uvent/utils/datastructures/queue/FastQueue.h
@@ -11,7 +11,7 @@
 #include <cassert>
 #include <cstring>
 #include <utility>
-#include "include/uvent/utils/intrinsincs/optimizations.h"
+#include "uvent/utils/intrinsincs/optimizations.h"
 
 namespace usub::queue::single_thread
 {

--- a/include/uvent/utils/errors/IOErrors.h
+++ b/include/uvent/utils/errors/IOErrors.h
@@ -30,7 +30,13 @@ namespace usub::utils::errors {
         InvalidSocketFd,
         RecvFailed,
         RecvFromFailed,
-        InvalidAddressVariant
+        InvalidAddressVariant,
+        Timeout
+    };
+
+    enum class SocketError
+    {
+        Timeout
     };
 
     constexpr const char *toString(SendError err) noexcept {
@@ -43,6 +49,8 @@ namespace usub::utils::errors {
                 return "RecvFromFailed";
             case SendError::InvalidAddressVariant:
                 return "InvalidAddressVariant";
+            case SendError::Timeout:
+                return "Timeout";
             default:
                 return "UnknownSendError";
         }
@@ -74,6 +82,15 @@ namespace usub::utils::errors {
                 return "Unknown";
             default:
                 return "UnknownConnectError";
+        }
+    }
+
+    constexpr const char *toString(SocketError err) noexcept {
+        switch (err) {
+        case SocketError::Timeout:
+            return "Timeout";
+        default:
+            return "UnknownSendError";
         }
     }
 }

--- a/include/uvent/utils/net/socket.h
+++ b/include/uvent/utils/net/socket.h
@@ -7,7 +7,7 @@
 
 // USUB:
 #include "net.h"
-#include "include/uvent/system/Defines.h"
+#include "uvent/system/Defines.h"
 
 // STL:
 #include <string>

--- a/include/uvent/utils/sync/RefCountedSession.h
+++ b/include/uvent/utils/sync/RefCountedSession.h
@@ -7,7 +7,7 @@
 
 #include <atomic>
 #include <concepts>
-#include "include/uvent/utils/intrinsincs/optimizations.h"
+#include "uvent/utils/intrinsincs/optimizations.h"
 
 namespace usub::utils::sync::refc
 {

--- a/include/uvent/utils/sync/RefCountedSession.h
+++ b/include/uvent/utils/sync/RefCountedSession.h
@@ -15,11 +15,20 @@ namespace usub::utils::sync::refc
     inline constexpr uint64_t BUSY_MASK = 1ull << 62;
     inline constexpr uint64_t READING_MASK = 1ull << 61;
     inline constexpr uint64_t WRITING_MASK = 1ull << 60;
+    inline constexpr uint64_t DISCONNECTED_MASK = 1ull << 59;
 
-    inline constexpr uint64_t FLAGS_MASK =
-        (CLOSED_MASK | BUSY_MASK | READING_MASK | WRITING_MASK);
+    inline constexpr uint64_t FLAGS_MASK = (CLOSED_MASK | BUSY_MASK | READING_MASK | WRITING_MASK | DISCONNECTED_MASK);
 
-    inline constexpr uint64_t COUNT_MASK = ~FLAGS_MASK;
+    inline constexpr uint64_t REFCOUNT_BITS = 40;
+    inline constexpr uint64_t TIMEOUT_EPOCH_BITS = 19; // 40 + 19 = 59
+    static_assert(REFCOUNT_BITS + TIMEOUT_EPOCH_BITS == 59);
+
+    inline constexpr uint64_t REFCOUNT_MASK = (REFCOUNT_BITS == 64 ? ~0ull : ((1ull << REFCOUNT_BITS) - 1ull));
+    inline constexpr uint64_t TIMEOUT_EPOCH_SHIFT = REFCOUNT_BITS;
+    inline constexpr uint64_t TIMEOUT_EPOCH_MASK = ((1ull << TIMEOUT_EPOCH_BITS) - 1ull) << TIMEOUT_EPOCH_SHIFT;
+    inline constexpr uint64_t TIMEOUT_EPOCH_BUMP = 1ull << TIMEOUT_EPOCH_SHIFT;
+
+    inline constexpr uint64_t COUNT_MASK = REFCOUNT_MASK;
 
     template <class Derived>
     class RefCounted
@@ -28,16 +37,14 @@ namespace usub::utils::sync::refc
         RefCounted() noexcept = default;
         virtual ~RefCounted() = default;
 
-        bool try_add_ref() noexcept
-        {
+        bool try_add_ref() noexcept {
             auto& st = state();
             uint64_t s = st.load(std::memory_order_relaxed);
-            for (;;)
-            {
+            for (;;) {
                 if (is_closed(s)) return false;
                 if ((s & COUNT_MASK) == COUNT_MASK) return false;
-                if (st.compare_exchange_weak(
-                    s, s + 1, std::memory_order_acquire, std::memory_order_relaxed))
+                uint64_t ns = (s & ~COUNT_MASK) | ((s & COUNT_MASK) + 1);
+                if (st.compare_exchange_weak(s, ns, std::memory_order_acquire, std::memory_order_relaxed))
                     return true;
                 cpu_relax();
             }
@@ -65,6 +72,12 @@ namespace usub::utils::sync::refc
         __attribute__((always_inline)) void close_for_new_refs() noexcept
         {
             static_cast<Derived*>(this)->close_for_new_refs();
+        }
+
+        [[nodiscard]] __attribute__((always_inline)) bool is_disconnected_now() const noexcept
+        {
+            using namespace usub::utils::sync::refc;
+            return (this->state().load(std::memory_order_acquire) & DISCONNECTED_MASK) != 0;
         }
 
     protected:

--- a/include/uvent/utils/timer/Timer.h
+++ b/include/uvent/utils/timer/Timer.h
@@ -10,6 +10,7 @@
 #include <functional>
 #include <coroutine>
 
+#include "uvent/base/Predefines.h"
 #include "uvent/system/Defines.h"
 #include "uvent/tasks/AwaitableFrame.h"
 
@@ -24,11 +25,19 @@ namespace usub::uvent::utils
         INTERVAL
     };
 
-    task::Awaitable<void> timeout_coroutine(std::function<void()> f);
-
-    struct alignas(32) Timer
+    enum TimerTag
     {
-        Timer(timer_duration_t duration, int fd, TimerType type = TIMEOUT);
+        SOCKET_TIMEOUT,
+        OTHER
+    };
+
+    task::Awaitable<void> timeout_coroutine(std::function<void(void*)> f, void* arg);
+
+    class alignas(32) Timer
+    {
+    public:
+        friend class core::EPoller;
+        friend class TimerWheel;
 
         explicit Timer(timer_duration_t duration, TimerType type = TIMEOUT);
 
@@ -40,17 +49,21 @@ namespace usub::uvent::utils
 
         Timer& operator=(Timer&&) = delete;
 
+        void addFunction(std::function<void(void*)>& function, void* functionValue);
+
+        void addFunction(std::function<void(void*)>&& function, void* functionValue);
+
+    public:
         timeout_t expiryTime;
         timer_duration_t duration_ms;
         TimerType type;
+
+    private:
         std::coroutine_handle<> coro;
         bool active;
         uint64_t id;
         size_t slotIndex{0};
         size_t level{0};
-        int fd{-1};
-        timer_duration_t new_duration_ms{0};
-        std::function<void()> ref_dec;
     };
 
     enum class OpType : uint8_t { ADD, UPDATE, REMOVE };

--- a/include/uvent/utils/timer/Timer.h
+++ b/include/uvent/utils/timer/Timer.h
@@ -26,7 +26,7 @@ namespace usub::uvent::utils
 
     task::Awaitable<void> timeout_coroutine(std::function<void()> f);
 
-    struct Timer
+    struct alignas(32) Timer
     {
         Timer(timer_duration_t duration, int fd, TimerType type = TIMEOUT);
 

--- a/include/uvent/utils/timer/Timer.h
+++ b/include/uvent/utils/timer/Timer.h
@@ -10,8 +10,8 @@
 #include <functional>
 #include <coroutine>
 
-#include "include/uvent/system/Defines.h"
-#include "include/uvent/tasks/AwaitableFrame.h"
+#include "uvent/system/Defines.h"
+#include "uvent/tasks/AwaitableFrame.h"
 
 typedef uint64_t timer_duration_t;
 typedef uint64_t timeout_t;
@@ -49,8 +49,8 @@ namespace usub::uvent::utils
         size_t slotIndex{0};
         size_t level{0};
         int fd{-1};
-
         timer_duration_t new_duration_ms{0};
+        std::function<void()> ref_dec;
     };
 
     enum class OpType : uint8_t { ADD, UPDATE, REMOVE };

--- a/include/uvent/utils/timer/Timer.h
+++ b/include/uvent/utils/timer/Timer.h
@@ -10,8 +10,8 @@
 #include <functional>
 #include <coroutine>
 
-#include "include/uvent/system/Defines.h"
-#include "include/uvent/tasks/AwaitableFrame.h"
+#include "uvent/system/Defines.h"
+#include "uvent/tasks/AwaitableFrame.h"
 
 typedef uint64_t timer_duration_t;
 typedef uint64_t timeout_t;

--- a/include/uvent/utils/timer/TimerWheel.h
+++ b/include/uvent/utils/timer/TimerWheel.h
@@ -6,8 +6,8 @@
 #define UVENT_TIMER_H
 
 // USUB:
-#include "include/uvent/system/Defines.h"
-#include "include/uvent/tasks/AwaitableFrame.h"
+#include "uvent/system/Defines.h"
+#include "uvent/tasks/AwaitableFrame.h"
 #include "Timer.h"
 
 // STL:
@@ -23,8 +23,8 @@
 #include <cmath>
 #include <list>
 #include <map>
-#include "include/uvent/utils/datastructures/queue/ConcurrentQueues.h"
-#include "include/uvent/system/Settings.h"
+#include "uvent/utils/datastructures/queue/ConcurrentQueues.h"
+#include "uvent/system/Settings.h"
 
 typedef uint64_t timer_duration_t;
 typedef uint64_t timeout_t;
@@ -42,7 +42,7 @@ namespace usub::uvent::utils
 
         bool removeTimer(uint64_t timerId);
 
-        std::vector<std::coroutine_handle<>> tick();
+        void tick();
 
         int getNextTimeout() const;
 
@@ -62,7 +62,7 @@ namespace usub::uvent::utils
 
         void removeTimerFromWheel(Timer* timer);
 
-        void advance(std::vector<std::coroutine_handle<>>& timers);
+        void advance();
 
         void updateNextExpiryTime();
 

--- a/include/uvent/utils/timer/TimerWheel.h
+++ b/include/uvent/utils/timer/TimerWheel.h
@@ -66,6 +66,12 @@ namespace usub::uvent::utils
 
         void updateNextExpiryTime();
 
+        inline static bool is_due(timeout_t now, timeout_t expiry, uint64_t interval) noexcept {
+            if (expiry <= now) return true;
+            const uint64_t diff = expiry - now;
+            return diff < interval;
+        }
+
     private:
         struct Wheel
         {

--- a/include/uvent/utils/timer/TimerWheel.h
+++ b/include/uvent/utils/timer/TimerWheel.h
@@ -6,8 +6,8 @@
 #define UVENT_TIMER_H
 
 // USUB:
-#include "include/uvent/system/Defines.h"
-#include "include/uvent/tasks/AwaitableFrame.h"
+#include "uvent/system/Defines.h"
+#include "uvent/tasks/AwaitableFrame.h"
 #include "Timer.h"
 
 // STL:
@@ -23,8 +23,8 @@
 #include <cmath>
 #include <list>
 #include <map>
-#include "include/uvent/utils/datastructures/queue/ConcurrentQueues.h"
-#include "include/uvent/system/Settings.h"
+#include "uvent/utils/datastructures/queue/ConcurrentQueues.h"
+#include "uvent/system/Settings.h"
 
 typedef uint64_t timer_duration_t;
 typedef uint64_t timeout_t;

--- a/src/Uvent.cpp
+++ b/src/Uvent.cpp
@@ -2,7 +2,7 @@
 // Created by kirill on 11/17/24.
 //
 
-#include "include/uvent/Uvent.h"
+#include "uvent/Uvent.h"
 
 namespace usub {
     Uvent::Uvent(int threadCount) : pool(threadCount) {

--- a/src/net/AwaiterOperations.cpp
+++ b/src/net/AwaiterOperations.cpp
@@ -72,7 +72,7 @@ namespace usub::uvent::net::detail
     {
         auto c = std::coroutine_handle<uvent::detail::AwaitableFrameBase>::from_address(h.address());
         this->header_->first = c;
-        c.promise().unset_awaited();
+        c.promise().set_awaited();
         this->header_->clear_busy();
     }
 

--- a/src/net/AwaiterOperations.cpp
+++ b/src/net/AwaiterOperations.cpp
@@ -2,8 +2,8 @@
 // Created by root on 9/13/25.
 //
 
-#include "include/uvent/net/AwaiterOperations.h"
-#include "include/uvent/system/SystemContext.h"
+#include "uvent/net/AwaiterOperations.h"
+#include "uvent/system/SystemContext.h"
 
 namespace usub::uvent::net::detail
 {
@@ -21,7 +21,7 @@ namespace usub::uvent::net::detail
         if (!this->header_->is_reading_now())
         {
             system::this_thread::detail::pl->updateEvent(this->header_, core::READ);
-            this->header_->is_reading_now();
+            this->header_->try_mark_reading();
         }
         auto c = std::coroutine_handle<uvent::detail::AwaitableFrameBase>::from_address(h.address());
         c.promise().set_awaited();
@@ -47,7 +47,7 @@ namespace usub::uvent::net::detail
         if (!this->header_->is_writing_now())
         {
             system::this_thread::detail::pl->updateEvent(this->header_, core::WRITE);
-            this->header_->is_writing_now();
+            this->header_->try_mark_writing();
         }
         auto c = std::coroutine_handle<uvent::detail::AwaitableFrameBase>::from_address(h.address());
         c.promise().set_awaited();

--- a/src/net/AwaiterOperations.cpp
+++ b/src/net/AwaiterOperations.cpp
@@ -2,8 +2,8 @@
 // Created by root on 9/13/25.
 //
 
-#include "include/uvent/net/AwaiterOperations.h"
-#include "include/uvent/system/SystemContext.h"
+#include "uvent/net/AwaiterOperations.h"
+#include "uvent/system/SystemContext.h"
 
 namespace usub::uvent::net::detail
 {

--- a/src/net/Socket.cpp
+++ b/src/net/Socket.cpp
@@ -2,4 +2,4 @@
 // Created by root on 9/11/25.
 //
 
-#include "include/uvent/net/Socket.h"
+#include "uvent/net/Socket.h"

--- a/src/net/SocketMetadata.cpp
+++ b/src/net/SocketMetadata.cpp
@@ -2,7 +2,7 @@
 // Created by root on 9/13/25.
 //
 
-#include "include/uvent/net/SocketMetadata.h"
+#include "uvent/net/SocketMetadata.h"
 
 namespace usub::uvent::net
 {

--- a/src/net/SocketMetadata.cpp
+++ b/src/net/SocketMetadata.cpp
@@ -3,3 +3,7 @@
 //
 
 #include "include/uvent/net/SocketMetadata.h"
+
+namespace usub::uvent::net
+{
+}

--- a/src/poll/EPoller.cpp
+++ b/src/poll/EPoller.cpp
@@ -2,10 +2,10 @@
 // Created by kirill on 11/15/24.
 //
 
-#include "include/uvent/poll/EPoller.h"
-#include "include/uvent/system/Settings.h"
-#include "include/uvent/utils/thread/ThreadStats.h"
-#include "include/uvent/system/SystemContext.h"
+#include "uvent/poll/EPoller.h"
+#include "uvent/system/Settings.h"
+#include "uvent/utils/thread/ThreadStats.h"
+#include "uvent/system/SystemContext.h"
 #include "uvent/net/Socket.h"
 
 namespace usub::uvent::core

--- a/src/poll/EPoller.cpp
+++ b/src/poll/EPoller.cpp
@@ -2,10 +2,10 @@
 // Created by kirill on 11/15/24.
 //
 
-#include "include/uvent/poll/EPoller.h"
-#include "include/uvent/system/Settings.h"
-#include "include/uvent/utils/thread/ThreadStats.h"
-#include "include/uvent/system/SystemContext.h"
+#include "uvent/poll/EPoller.h"
+#include "uvent/system/Settings.h"
+#include "uvent/utils/thread/ThreadStats.h"
+#include "uvent/system/SystemContext.h"
 #include "uvent/net/Socket.h"
 
 namespace usub::uvent::core
@@ -22,32 +22,45 @@ namespace usub::uvent::core
     {
         struct epoll_event event{};
         event.data.ptr = reinterpret_cast<void*>(header);
+
+        if (header->is_tcp() && !header->is_passive())
+            event.events = EPOLLET;
+
         switch (initialState)
         {
-        case READ: event.events = EPOLLIN | EPOLLET;
+        case READ: event.events |= EPOLLIN;
             break;
-        case WRITE: event.events = EPOLLOUT | EPOLLET;
+        case WRITE: event.events |= EPOLLOUT;
             break;
-        default: event.events = EPOLLIN | EPOLLOUT | EPOLLET;
+        default: event.events |= EPOLLIN | EPOLLOUT;
             break;
         }
+
 #if UVENT_DEBUG
-    spdlog::info("Socket added: {}", header->fd);
+        spdlog::info("Socket added: fd={} et={} in={} out={}",
+                     header->fd,
+                     bool(event.events & EPOLLET),
+                     bool(event.events & EPOLLIN),
+                     bool(event.events & EPOLLOUT));
 #endif
+
         epoll_ctl(this->poll_fd, EPOLL_CTL_ADD, header->fd, &event);
 
-        if ((header->socket_info & static_cast<uint8_t>(net::Proto::TCP)) &&
-            !(header->socket_info & static_cast<uint8_t>(net::Role::PASSIVE)))
+        if (header->is_tcp() && !header->is_passive())
         {
-            auto& st = header->state;
             {
-                uint64_t s = st.load(std::memory_order_relaxed);
+                uint64_t s = header->state.load(std::memory_order_relaxed);
                 for (;;)
                 {
-                    if ((s & usub::utils::sync::refc::COUNT_MASK) == usub::utils::sync::refc::COUNT_MASK) break;
-                    uint64_t ns = (s & ~usub::utils::sync::refc::COUNT_MASK) | ((s &
-                        usub::utils::sync::refc::COUNT_MASK) + 1);
-                    if (st.compare_exchange_weak(s, ns, std::memory_order_acquire, std::memory_order_relaxed)) break;
+                    if (s & usub::utils::sync::refc::CLOSED_MASK) break;
+
+                    const uint64_t cnt = (s & usub::utils::sync::refc::COUNT_MASK);
+                    if (cnt == usub::utils::sync::refc::COUNT_MASK) break;
+                    const uint64_t ns = (s & ~usub::utils::sync::refc::COUNT_MASK) | (cnt + 1);
+
+                    if (header->state.compare_exchange_weak(
+                        s, ns, std::memory_order_acq_rel, std::memory_order_relaxed))
+                        break;
                     cpu_relax();
                 }
             }
@@ -56,19 +69,41 @@ namespace usub::uvent::core
 
             auto coro = utils::timeout_coroutine([this, header]
             {
-                header->timeout_epoch_bump(header->state);
+                const uint64_t expected = header->timeout_epoch_load();
 
-                if (header->first) system::this_thread::detail::q->enqueue(header->first);
-                if (header->second) system::this_thread::detail::q->enqueue(header->second);
+                if (!header->try_mark_busy())
+                {
+                    this->wheel->updateTimer(header->timer_id, settings::timeout_duration_ms);
+                    header->state.fetch_sub(1, std::memory_order_acq_rel);
+                    return;
+                }
 
-                header->state.fetch_sub(1, std::memory_order_release);
+                if (header->timeout_epoch_changed(expected))
+                {
+                    header->clear_busy();
+                    this->wheel->updateTimer(header->timer_id, settings::timeout_duration_ms);
+                    header->state.fetch_sub(1, std::memory_order_acq_rel);
+                    return;
+                }
+
+                auto r = std::exchange(header->first, nullptr);
+                auto w = std::exchange(header->second, nullptr);
+                header->clear_reading();
+                header->clear_writing();
+                header->clear_busy();
+
+                epoll_ctl(this->poll_fd, EPOLL_CTL_DEL, header->fd, nullptr);
+                ::close(header->fd);
+                if (r) system::this_thread::detail::q->enqueue(r);
+                if (w) system::this_thread::detail::q->enqueue(w);
+
+                header->state.fetch_sub(1, std::memory_order_acq_rel);
             });
 
             timer->coro = coro.get_promise()->get_coroutine_handle();
             header->timer_id = this->wheel->addTimer(timer);
         }
-        else if ((header->socket_info & static_cast<uint8_t>(net::Proto::TCP)) &&
-            (header->socket_info & static_cast<uint8_t>(net::Role::PASSIVE)))
+        else if (header->is_tcp() && header->is_passive())
         {
             utils::detail::thread::is_started.store(true, std::memory_order_relaxed);
         }
@@ -79,9 +114,9 @@ namespace usub::uvent::core
     {
         struct epoll_event event{};
         event.data.ptr = reinterpret_cast<void*>(header);
-        event.events = 0;
-        if (header->is_writing_now()) event.events |= (EPOLLOUT | EPOLLET);
-        if (header->is_reading_now()) event.events |= (EPOLLIN | EPOLLET);
+        if (!(header->is_tcp() && header->is_passive())) event.events = EPOLLET;
+        if (header->is_writing_now()) event.events |= EPOLLOUT;
+        if (header->is_reading_now()) event.events |= EPOLLIN;
 
         switch (initialState)
         {
@@ -97,14 +132,14 @@ namespace usub::uvent::core
         }
 
 #if UVENT_DEBUG
-        spdlog::info("Updating socket #{} with events: {} (READ: {}, WRITE: {})",
-                     socket->fd, static_cast<int>(event.events),
+        spdlog::info("Updating socket #{} READ: {}, WRITE: {}",
+                     header->fd,
                      static_cast<bool>(event.events & EPOLLIN),
                      static_cast<bool>(event.events & EPOLLOUT));
-        spdlog::info("Socket #{} updated with state: {}, read state: {}, write state: {}", socket->fd,
+        spdlog::info("Socket #{} updated with state: {}, read state: {}, write state: {}", header->fd,
                      static_cast<int>(initialState),
-                     socket->is_reading_now(),
-                     socket->is_writing_now());
+                     header->is_reading_now(),
+                     header->is_writing_now());
 #endif
 
         int result = epoll_ctl(this->poll_fd, EPOLL_CTL_MOD, header->fd, &event);
@@ -113,7 +148,7 @@ namespace usub::uvent::core
         {
             if (errno == ENOENT || errno == EBADF || errno == ENOTSOCK)
             {
-                spdlog::info("Socket #{} is closed or invalid, ignoring epoll_ctl modification.", socket->fd);
+                spdlog::info("Socket #{} is closed or invalid, ignoring epoll_ctl modification.", header->fd);
                 return;
             }
             throw std::system_error(errno, std::generic_category(),
@@ -128,19 +163,12 @@ namespace usub::uvent::core
         spdlog::info("Socket removed: {}", header->fd);
 #endif
         using namespace usub::utils::sync::refc;
-        uint64_t s = header->state.load(std::memory_order_relaxed);
-        for (;;) {
-            if (s & CLOSED_MASK) break;
-            const uint64_t ns = s | DISCONNECTED_MASK | CLOSED_MASK;
-            if (header->state.compare_exchange_weak(s, ns, std::memory_order_release, std::memory_order_relaxed)) break;
-            cpu_relax();
-        }
+
         epoll_ctl(this->poll_fd, EPOLL_CTL_DEL, header->fd, nullptr);
         this->wheel->removeTimer(header->timer_id);
         ::close(header->fd);
-        header->fd = -1;
 
-        if (header->first)  system::this_thread::detail::q->enqueue(header->first);
+        if (header->first) system::this_thread::detail::q->enqueue(header->first);
         if (header->second) system::this_thread::detail::q->enqueue(header->second);
     }
 
@@ -157,24 +185,23 @@ namespace usub::uvent::core
             auto& event = this->events[i];
             auto* sock = static_cast<net::SocketHeader*>(event.data.ptr);
             if (sock->is_busy_now() || sock->is_disconnected_now()) continue;
-            if (!(sock->socket_info & static_cast<uint8_t>(net::Proto::TCP) & (sock->socket_info & static_cast<uint8_t>(
-                    net::Role::PASSIVE))) &
-                (event.events & (EPOLLHUP | EPOLLRDHUP | EPOLLERR)))
+            constexpr uint32_t errmask = EPOLLHUP | EPOLLRDHUP | EPOLLERR;
+            if ((event.events & (EPOLLHUP | EPOLLRDHUP | EPOLLERR)))
             {
                 this->removeEvent(sock, ALL);
                 continue;
             }
             sock->try_mark_busy();
-            if (event.events & EPOLLIN)
+            if (event.events & EPOLLIN && sock->first)
             {
 #if UVENT_DEBUG
                 spdlog::info("Socket #{} triggered as IN", sock->fd);
 #endif
-                system::this_thread::detail::q->enqueue(sock->first);
-                sock->first = nullptr;
+                auto c = std::exchange(sock->first, nullptr);
+                system::this_thread::detail::q->enqueue(c);
                 if (!(event.events & EPOLLOUT)) continue;
             }
-            if (event.events & EPOLLOUT)
+            if (event.events & EPOLLOUT && sock->second)
             {
 #if UVENT_DEBUG
                 spdlog::info("Socket #{} triggered as OUT", sock->fd);
@@ -182,43 +209,50 @@ namespace usub::uvent::core
                 if (sock->second)
                 {
                     if (!(sock->socket_info & static_cast<uint8_t>(net::AdditionalState::CONNECTION_PENDING)))
-                        system::this_thread::detail::q->enqueue(sock->second);
+                    {
+                        auto c = std::exchange(sock->second, nullptr);
+                        system::this_thread::detail::q->enqueue(c);
+                    }
                     else
                     {
                         int err = 0;
                         socklen_t len = sizeof(err);
-                        getsockopt(event.data.fd, SOL_SOCKET, SO_ERROR, &err, &len);
+                        getsockopt(sock->fd, SOL_SOCKET, SO_ERROR, &err, &len);
+                        sock->socket_info &= ~static_cast<uint8_t>(net::AdditionalState::CONNECTION_PENDING);
                         if (err != 0)
                         {
-                            sock->socket_info &= ~static_cast<uint8_t>(net::AdditionalState::CONNECTION_PENDING);
-                            sock->socket_info &= static_cast<uint8_t>(net::AdditionalState::CONNECTION_FAILED);
+                            sock->socket_info |= static_cast<uint8_t>(net::AdditionalState::CONNECTION_FAILED);
                         }
                     }
-                    sock->second = nullptr;
                 }
             }
         }
         if (n == this->events.size()) this->events.resize(this->events.size() << 1);
-        this->unlock();
         system::this_thread::detail::g_qsbr.leave();
         return n > 0;
     }
 
     bool EPoller::try_lock()
     {
-        this->is_locked.store(true, std::memory_order_seq_cst);
-        return this->lock.try_acquire();
+        if (this->lock.try_acquire())
+        {
+            this->is_locked.store(true, std::memory_order_release);
+            return true;
+        }
+        return false;
     }
 
     void EPoller::unlock()
     {
+        this->is_locked.store(false, std::memory_order_release);
         this->lock.release();
-        this->is_locked.store(false, std::memory_order_seq_cst);
     }
 
     void EPoller::lock_poll(int timeout)
     {
         this->lock.acquire();
+        this->is_locked.store(true, std::memory_order_release);
         this->poll(timeout);
+        this->unlock();
     }
 }

--- a/src/poll/PollerBase.cpp
+++ b/src/poll/PollerBase.cpp
@@ -6,4 +6,9 @@
 
 namespace usub::uvent::core {
     PollerBase::PollerBase() {}
+
+    int PollerBase::get_poll_fd()
+    {
+        return this->poll_fd;
+    }
 }

--- a/src/poll/PollerBase.cpp
+++ b/src/poll/PollerBase.cpp
@@ -2,7 +2,7 @@
 // Created by kirill on 11/11/24.
 //
 
-#include "include/uvent/poll/PollerBase.h"
+#include "uvent/poll/PollerBase.h"
 
 namespace usub::uvent::core {
     PollerBase::PollerBase() {}

--- a/src/poll/PollerBase.cpp
+++ b/src/poll/PollerBase.cpp
@@ -5,5 +5,5 @@
 #include "include/uvent/poll/PollerBase.h"
 
 namespace usub::uvent::core {
-    PollerBase::PollerBase(uint64_t timeoutDuration_ms) : timeoutDuration_ms(timeoutDuration_ms) {}
+    PollerBase::PollerBase() {}
 }

--- a/src/pool/ThreadPool.cpp
+++ b/src/pool/ThreadPool.cpp
@@ -2,7 +2,7 @@
 // Created by Kirill Zhukov on 07.11.2024.
 //
 
-#include "include/uvent/pool/ThreadPool.h"
+#include "uvent/pool/ThreadPool.h"
 
 namespace usub::uvent {
     ThreadPool::ThreadPool(int size) {

--- a/src/system/Defines.cpp
+++ b/src/system/Defines.cpp
@@ -2,7 +2,7 @@
 // Created by Kirill Zhukov on 09/28/2024.
 //
 
-#include "include/uvent/system/Defines.h"
+#include "uvent/system/Defines.h"
 
 #if UVENT_DEBUG
 

--- a/src/system/SystemContext.cpp
+++ b/src/system/SystemContext.cpp
@@ -2,12 +2,12 @@
 // Created by kirill on 11/20/24.
 //
 
-#include "include/uvent/system/SystemContext.h"
-#include "include/uvent/tasks/AwaitableFrame.h"
+#include "uvent/system/SystemContext.h"
+#include "uvent/tasks/AwaitableFrame.h"
 
 #ifdef OS_LINUX
 
-#include "include/uvent/poll/EPoller.h"
+#include "uvent/poll/EPoller.h"
 
 #elif OS_BSD
 #include "poll/KPoller.h"

--- a/src/system/Thread.cpp
+++ b/src/system/Thread.cpp
@@ -55,9 +55,9 @@ namespace usub::uvent::system
                                   : 0);
             }
             highPerfTimer.reset();
-            while (true)
+            while (!q->empty())
             {
-                if (q->empty() || highPerfTimer.elapsed_ms() >= 291) break;
+                if (highPerfTimer.elapsed_ms() >= 291) break;
 
                 const size_t n = system::this_thread::detail::q->dequeue_bulk(
                     this->tmp_tasks_.data(), this->tmp_tasks_.size());

--- a/src/system/Thread.cpp
+++ b/src/system/Thread.cpp
@@ -2,9 +2,9 @@
 // Created by Kirill Zhukov on 07.11.2024.
 //
 
-#include "include/uvent/system/Thread.h"
+#include "uvent/system/Thread.h"
 #include <utility>
-#include "include/uvent/net/Socket.h"
+#include "uvent/net/Socket.h"
 
 namespace usub::uvent::system
 {

--- a/src/system/Thread.cpp
+++ b/src/system/Thread.cpp
@@ -2,9 +2,9 @@
 // Created by Kirill Zhukov on 07.11.2024.
 //
 
-#include "include/uvent/system/Thread.h"
+#include "uvent/system/Thread.h"
 #include <utility>
-#include "include/uvent/net/Socket.h"
+#include "uvent/net/Socket.h"
 
 namespace usub::uvent::system
 {
@@ -44,6 +44,7 @@ namespace usub::uvent::system
                                    ? next_timeout
                                    : 5000
                              : 0);
+                pl->unlock();
             }
             else if (q->empty() && q_c->empty())
             {
@@ -86,9 +87,7 @@ namespace usub::uvent::system
             }
             if (wh->mtx.try_lock())
             {
-                auto tick_res = wh->tick();
-                for (auto& timer : tick_res)
-                    system::this_thread::detail::q->enqueue(timer);
+                wh->tick();
                 wh->mtx.unlock();
             }
             if (st->getSize() > 0)

--- a/src/system/Thread.cpp
+++ b/src/system/Thread.cpp
@@ -40,7 +40,7 @@ namespace usub::uvent::system
             {
                 auto next_timeout = wh->getNextTimeout();
                 pl->poll((q->empty() && utils::detail::thread::is_started.load(std::memory_order_relaxed))
-                             ? (next_timeout <= 0)
+                             ? (next_timeout > 0)
                                    ? next_timeout
                                    : 5000
                              : 0);
@@ -49,7 +49,7 @@ namespace usub::uvent::system
             {
                 auto next_timeout = wh->getNextTimeout();
                 pl->lock_poll((q->empty() && utils::detail::thread::is_started.load(std::memory_order_relaxed))
-                                  ? (next_timeout <= 0)
+                                  ? (next_timeout > 0)
                                         ? next_timeout
                                         : 5000
                                   : 0);

--- a/src/tasks/Awaitable.cpp
+++ b/src/tasks/Awaitable.cpp
@@ -2,8 +2,8 @@
 // Created by Kirill Zhukov on 07.11.2024.
 //
 
-#include "include/uvent/tasks/Awaitable.h"
-#include "include/uvent/tasks/AwaitableFrame.h"
+#include "uvent/tasks/Awaitable.h"
+#include "uvent/tasks/AwaitableFrame.h"
 
 namespace usub::uvent::task {
 }

--- a/src/tasks/AwaitableFrame.cpp
+++ b/src/tasks/AwaitableFrame.cpp
@@ -2,8 +2,8 @@
 // Created by kirill on 1/4/25.
 //
 
-#include "include/uvent/tasks/AwaitableFrame.h"
-#include "include/uvent/system/SystemContext.h"
+#include "uvent/tasks/AwaitableFrame.h"
+#include "uvent/system/SystemContext.h"
 
 namespace usub::uvent::detail {
     void AwaitableFrameBase::destroy(DestroyingPolicy policy) {

--- a/src/tasks/SharedTasks.cpp
+++ b/src/tasks/SharedTasks.cpp
@@ -2,7 +2,7 @@
 // Created by kirill on 11/17/24.
 //
 
-#include "include/uvent/tasks/SharedTasks.h"
+#include "uvent/tasks/SharedTasks.h"
 
 namespace usub::uvent::task {
 

--- a/src/utils/buffer/DynamicBuffer.cpp
+++ b/src/utils/buffer/DynamicBuffer.cpp
@@ -2,7 +2,7 @@
 // Created by kirill on 5/21/25.
 //
 
-#include "include/uvent/utils/buffer/DynamicBuffer.h"
+#include "uvent/utils/buffer/DynamicBuffer.h"
 
 namespace usub::uvent::utils {
     void DynamicBuffer::reserve(size_t n) {

--- a/src/utils/datastructures/queue/ConcurrentQueues.cpp
+++ b/src/utils/datastructures/queue/ConcurrentQueues.cpp
@@ -2,4 +2,4 @@
 // Created by root on 9/9/25.
 //
 
-#include "include/uvent/utils/datastructures/queue/ConcurrentQueues.h"
+#include "uvent/utils/datastructures/queue/ConcurrentQueues.h"

--- a/src/utils/datastructures/queue/FastQueue.cpp
+++ b/src/utils/datastructures/queue/FastQueue.cpp
@@ -2,4 +2,4 @@
 // Created by kirill on 5/7/25.
 //
 
-#include "include/uvent/utils/datastructures/queue/FastQueue.h"
+#include "uvent/utils/datastructures/queue/FastQueue.h"

--- a/src/utils/errors/IOErrors.cpp
+++ b/src/utils/errors/IOErrors.cpp
@@ -2,7 +2,7 @@
 // Created by kirill on 5/1/25.
 //
 
-#include "include/uvent/utils/errors/IOErrors.h"
+#include "uvent/utils/errors/IOErrors.h"
 
 namespace usub::utils::errors {
 }

--- a/src/utils/net/socket.cpp
+++ b/src/utils/net/socket.cpp
@@ -2,7 +2,7 @@
 // Created by kirill on 8/30/24.
 //
 
-#include "include/uvent/utils/net/socket.h"
+#include "uvent/utils/net/socket.h"
 
 namespace usub::uvent::utils::socket {
     int createSocket(int port, const std::string &ip_addr, int backlog, net::IPV ipv, net::SocketAddressType socType) {

--- a/src/utils/sync/QSBR.cpp
+++ b/src/utils/sync/QSBR.cpp
@@ -2,7 +2,7 @@
 // Created by root on 9/11/25.
 //
 
-#include "include/uvent/utils/sync/QSBR.h"
+#include "uvent/utils/sync/QSBR.h"
 
 namespace usub::utils::sync
 {

--- a/src/utils/sync/RefCountedSession.cpp
+++ b/src/utils/sync/RefCountedSession.cpp
@@ -2,7 +2,7 @@
 // Created by root on 9/11/25.
 //
 
-#include "include/uvent/utils/sync/RefCountedSession.h"
+#include "uvent/utils/sync/RefCountedSession.h"
 
 namespace usub::utils::sync::refc
 {

--- a/src/utils/thread/ThreadStats.cpp
+++ b/src/utils/thread/ThreadStats.cpp
@@ -2,7 +2,7 @@
 // Created by kirill on 1/29/25.
 //
 
-#include "include/uvent/utils/thread/ThreadStats.h"
+#include "uvent/utils/thread/ThreadStats.h"
 
 namespace usub::uvent::utils::detail::thread
 {

--- a/src/utils/timer/HighPerfomanceTimer.cpp
+++ b/src/utils/timer/HighPerfomanceTimer.cpp
@@ -2,7 +2,7 @@
 // Created by kirill on 5/7/25.
 //
 
-#include "include/uvent/utils/timer/HighPerfomanceTimer.h"
+#include "uvent/utils/timer/HighPerfomanceTimer.h"
 
 namespace usub::utils {
     HighPerfTimer::HighPerfTimer() {

--- a/src/utils/timer/Timer.cpp
+++ b/src/utils/timer/Timer.cpp
@@ -2,7 +2,7 @@
 // Created by root on 9/9/25.
 //
 
-#include "include/uvent/utils/timer/Timer.h"
+#include "uvent/utils/timer/Timer.h"
 
 namespace usub::uvent::utils
 {

--- a/src/utils/timer/Timer.cpp
+++ b/src/utils/timer/Timer.cpp
@@ -6,11 +6,21 @@
 
 namespace usub::uvent::utils
 {
-    Timer::Timer(timer_duration_t duration, int fd, TimerType type) : duration_ms(duration), fd(fd), type(type),
-                                                                      expiryTime(0),
-                                                                      active(true), id(0) {}
-
-    Timer::Timer(timer_duration_t duration, TimerType type) : duration_ms(duration), fd(-1), type(type),
+    Timer::Timer(timer_duration_t duration, TimerType type) : duration_ms(duration), type(type),
                                                               expiryTime(0),
-                                                              active(true), id(0) {}
+                                                              active(true), id(0)
+    {
+    }
+
+    void Timer::addFunction(std::function<void(void*)>& function, void* functionValue)
+    {
+        auto aw = timeout_coroutine(std::move(function), functionValue);
+        this->coro = aw.get_promise()->get_coroutine_handle();
+    }
+
+    void Timer::addFunction(std::function<void(void*)>&& function, void* functionValue)
+    {
+        auto aw = timeout_coroutine(std::move(function), functionValue);
+        this->coro = aw.get_promise()->get_coroutine_handle();
+    }
 }

--- a/src/utils/timer/TimerWheel.cpp
+++ b/src/utils/timer/TimerWheel.cpp
@@ -16,13 +16,14 @@ namespace usub::uvent::utils
          LEVEL 2: 256 slots, interval 65,536 ms\n
          LEVEL 3: 256 slots, interval 16,777,216 ms
         */
-        for (int i = 0; i < settings::tw_levels; i++) this->wheels_.emplace_back(256, std::pow(256, i));
-        this->ops_.reserve(settings::max_pre_allocated_timer_wheel_operations_items);
+        for (int i = 0; i < settings::tw_levels; i++) this->wheels_.emplace_back(256, (1ull << (8 * i)));
+        this->ops_.resize(settings::max_pre_allocated_timer_wheel_operations_items);
     }
 
 
     uint64_t TimerWheel::addTimer(Timer* timer)
     {
+
         timer->expiryTime = getCurrentTime() + timer->duration_ms;
         timer->id = timerIdCounter_.fetch_add(1, std::memory_order_relaxed) + 1;
 
@@ -31,7 +32,6 @@ namespace usub::uvent::utils
             .timer = timer
         };
         while (!this->timer_operations_queue.try_enqueue(op)) cpu_relax();
-
         return timer->id;
     }
 
@@ -139,19 +139,25 @@ namespace usub::uvent::utils
     void TimerWheel::updateNextExpiryTime()
     {
         this->nextExpiryTime_ = 0;
-        for (const auto& wheel : this->wheels_)
-            if (wheel.minExpiryTime_ != 0)
-                if (this->nextExpiryTime_ == 0 || wheel.minExpiryTime_ < this->nextExpiryTime_)
-                    this->nextExpiryTime_ = wheel.minExpiryTime_;
+        for (const auto& wheel : this->wheels_) {
+            for (const auto& bucket : wheel.buckets_) {
+                for (const auto* t : bucket) {
+                    if (!t->active) continue;
+                    if (this->nextExpiryTime_ == 0 || t->expiryTime < this->nextExpiryTime_)
+                        this->nextExpiryTime_ = t->expiryTime;
+                }
+            }
+        }
     }
+
 
     std::vector<std::coroutine_handle<>> TimerWheel::tick()
     {
         while (true)
         {
-            size_t n = this->timer_operations_queue.try_dequeue_bulk(this->ops_.data(), this->ops_.size());
-            if (n == 0)
-                break;
+            const size_t cap = this->ops_.size();
+            size_t n = this->timer_operations_queue.try_dequeue_bulk(this->ops_.data(), cap);
+            if (n == 0) break;
 
             for (size_t i = 0; i < n; ++i)
             {
@@ -160,9 +166,9 @@ namespace usub::uvent::utils
                 {
                 case OpType::ADD:
                     addTimerToWheel(op.timer, op.timer->expiryTime);
-                    timerMap_[op.timer->id] = op.timer;
                     ++this->activeTimerCount_;
                     break;
+
                 case OpType::UPDATE:
                     {
                         auto it = timerMap_.find(op.id);
@@ -179,6 +185,7 @@ namespace usub::uvent::utils
                         }
                         break;
                     }
+
                 case OpType::REMOVE:
                     {
                         auto it = timerMap_.find(op.id_only);
@@ -195,44 +202,44 @@ namespace usub::uvent::utils
                                 delete timer;
                             }
                         }
+                        break;
                     }
-                    break;
                 }
             }
         }
 
-        timeout_t newTime = getCurrentTime();
-        uint64_t elapsedTime = newTime - this->currentTime_;
+        const timeout_t newTime = getCurrentTime();
+        const uint64_t elapsed = newTime - this->currentTime_;
+        if (elapsed == 0) return {};
         this->currentTime_ = newTime;
 
-        uint64_t ticks = elapsedTime / this->wheels_[0].interval_;
+        uint64_t ticks = elapsed / this->wheels_[0].interval_;
         if (ticks == 0) ticks = 1;
 
-        std::vector<std::coroutine_handle<>> timers;
-        for (uint64_t i = 0; i < ticks; ++i) advance(timers);
-        return std::move(timers);
+        std::vector<std::coroutine_handle<>> ready;
+        for (uint64_t i = 0; i < ticks; ++i) advance(ready);
+        return ready;
     }
+
 
     void TimerWheel::advance(std::vector<std::coroutine_handle<>>& timers)
     {
         for (auto& wheel : this->wheels_)
         {
             auto& bucket = wheel.buckets_[wheel.currentSlot_];
-            auto it = bucket.begin();
-
-            while (it != bucket.end())
+            for (auto it = bucket.begin(); it != bucket.end();)
             {
                 Timer* timer = *it;
+
                 if (!timer->active)
                 {
                     it = bucket.erase(it);
                     continue;
                 }
 
-                uint64_t diff = timer->expiryTime - currentTime_;
-                if (diff < wheel.interval_)
+                if (is_due(this->currentTime_, timer->expiryTime, wheel.interval_))
                 {
-                    timers.push_back(timer->coro);
+                    if (timer->coro) timers.push_back(timer->coro);
                     if (timer->type == INTERVAL)
                     {
                         timer->expiryTime += timer->duration_ms;
@@ -242,7 +249,7 @@ namespace usub::uvent::utils
                     {
                         timer->active = false;
                         this->timerMap_.erase(timer->id);
-                        this->activeTimerCount_--;
+                        --this->activeTimerCount_;
                         delete timer;
                     }
                     it = bucket.erase(it);

--- a/src/utils/timer/TimerWheel.cpp
+++ b/src/utils/timer/TimerWheel.cpp
@@ -23,7 +23,6 @@ namespace usub::uvent::utils
 
     uint64_t TimerWheel::addTimer(Timer* timer)
     {
-
         timer->expiryTime = getCurrentTime() + timer->duration_ms;
         timer->id = timerIdCounter_.fetch_add(1, std::memory_order_relaxed) + 1;
 
@@ -139,9 +138,12 @@ namespace usub::uvent::utils
     void TimerWheel::updateNextExpiryTime()
     {
         this->nextExpiryTime_ = 0;
-        for (const auto& wheel : this->wheels_) {
-            for (const auto& bucket : wheel.buckets_) {
-                for (const auto* t : bucket) {
+        for (const auto& wheel : this->wheels_)
+        {
+            for (const auto& bucket : wheel.buckets_)
+            {
+                for (const auto* t : bucket)
+                {
                     if (!t->active) continue;
                     if (this->nextExpiryTime_ == 0 || t->expiryTime < this->nextExpiryTime_)
                         this->nextExpiryTime_ = t->expiryTime;
@@ -182,6 +184,11 @@ namespace usub::uvent::utils
                                 t->expiryTime = getCurrentTime() + t->duration_ms;
                                 addTimerToWheel(t, t->expiryTime);
                             }
+                        } else
+                        {
+                            auto* t = new Timer(op.new_dur,TIMEOUT);
+                            addTimerToWheel(t, t->expiryTime);
+                            ++this->activeTimerCount_;
                         }
                         break;
                     }
@@ -271,9 +278,9 @@ namespace usub::uvent::utils
         return this->activeTimerCount_ == 0;
     }
 
-    task::Awaitable<void> timeout_coroutine(std::function<void()> f)
+    task::Awaitable<void> timeout_coroutine(std::function<void(void*)> f, void* arg)
     {
-        f();
+        f(arg);
         co_return;
     }
 }

--- a/src/utils/timer/TimerWheel.cpp
+++ b/src/utils/timer/TimerWheel.cpp
@@ -2,7 +2,7 @@
 // Created by kirill on 8/27/24.
 //
 
-#include "include/uvent/utils/timer/TimerWheel.h"
+#include "uvent/utils/timer/TimerWheel.h"
 
 namespace usub::uvent::utils
 {


### PR DESCRIPTION
Due error in timer wheel logic there were no timeouts. This fix brings new features such as setting up timeouts in user space:
```cpp
task::Awaitable<void> clientCoro(net::TCPClientSocket socket) {
    static constexpr size_t max_read_size = 64 * 1024;
    utils::DynamicBuffer buffer;
    buffer.reserve(max_read_size);

    static const std::string_view httpResponse =
            "HTTP/1.1 200 OK\r\n"
            "Content-Type: application/json\r\n"
            "Content-Length: 20\r\n"
            "\r\n"
            "{\"status\":\"success\"}";

    socket.set_timeout_ms(5000);
```