### PR TITLE
Et fixes

### DIFF
--- a/include/uvent/net/SocketMetadata.h
+++ b/include/uvent/net/SocketMetadata.h
@@ -217,6 +217,52 @@ namespace usub::uvent::net
 #endif
         }
 
+        UVENT_ALWAYS_INLINE_FN void mark_read_pending() noexcept
+        {
+            using namespace usub::utils::sync::refc;
+#ifndef UVENT_ENABLE_REUSEADDR
+            this->state.fetch_or(READ_PENDING_MASK, std::memory_order_release);
+#else
+            this->state |= READ_PENDING_MASK;
+#endif
+        }
+
+        UVENT_ALWAYS_INLINE_FN void mark_write_pending() noexcept
+        {
+            using namespace usub::utils::sync::refc;
+#ifndef UVENT_ENABLE_REUSEADDR
+            this->state.fetch_or(WRITE_PENDING_MASK, std::memory_order_release);
+#else
+            this->state |= WRITE_PENDING_MASK;
+#endif
+        }
+
+        UVENT_ALWAYS_INLINE_FN bool consume_read_pending() noexcept
+        {
+            using namespace usub::utils::sync::refc;
+#ifndef UVENT_ENABLE_REUSEADDR
+            const uint64_t prev = this->state.fetch_and(~READ_PENDING_MASK, std::memory_order_acq_rel);
+            return (prev & READ_PENDING_MASK) != 0;
+#else
+            const bool was = (this->state & READ_PENDING_MASK) != 0;
+            this->state &= ~READ_PENDING_MASK;
+            return was;
+#endif
+        }
+
+        UVENT_ALWAYS_INLINE_FN bool consume_write_pending() noexcept
+        {
+            using namespace usub::utils::sync::refc;
+#ifndef UVENT_ENABLE_REUSEADDR
+            const uint64_t prev = this->state.fetch_and(~WRITE_PENDING_MASK, std::memory_order_acq_rel);
+            return (prev & WRITE_PENDING_MASK) != 0;
+#else
+            const bool was = (this->state & WRITE_PENDING_MASK) != 0;
+            this->state &= ~WRITE_PENDING_MASK;
+            return was;
+#endif
+        }
+
         [[nodiscard]] UVENT_ALWAYS_INLINE_FN uint64_t timeout_epoch_snapshot() const noexcept
         {
             using namespace usub::utils::sync::refc;

--- a/include/uvent/system/Thread.h
+++ b/include/uvent/system/Thread.h
@@ -40,7 +40,7 @@ namespace usub::uvent::system
 
         Thread& operator=(const Thread&) = delete;
 
-        ~Thread() = default;
+        ~Thread();
 
         void run_current();
 

--- a/include/uvent/utils/sync/RefCountedSession.h
+++ b/include/uvent/utils/sync/RefCountedSession.h
@@ -18,7 +18,9 @@ namespace usub::utils::sync::refc
     inline constexpr uint64_t READING_MASK = 1ull << 61;
     inline constexpr uint64_t WRITING_MASK = 1ull << 60;
     inline constexpr uint64_t DISCONNECTED_MASK = 1ull << 59;
-    inline constexpr uint64_t FLAGS_MASK = (CLOSED_MASK | BUSY_MASK | READING_MASK | WRITING_MASK | DISCONNECTED_MASK);
+    inline constexpr uint64_t READ_PENDING_MASK = 1ull << 58;
+    inline constexpr uint64_t WRITE_PENDING_MASK = 1ull << 57;
+    inline constexpr uint64_t FLAGS_MASK = (CLOSED_MASK | BUSY_MASK | READING_MASK | WRITING_MASK | DISCONNECTED_MASK | READ_PENDING_MASK | WRITE_PENDING_MASK);
 
     inline constexpr uint64_t REFCOUNT_BITS = 40;
     inline constexpr uint64_t COUNT_MASK = (1ull << REFCOUNT_BITS) - 1ull;

--- a/src/net/AwaiterOperations.cpp
+++ b/src/net/AwaiterOperations.cpp
@@ -6,7 +6,9 @@ namespace usub::uvent::net::detail {
 
     AwaiterRead::AwaiterRead(SocketHeader* header) : header_(header) {}
 
-    bool AwaiterRead::await_ready() { return false; }
+    bool AwaiterRead::await_ready() {
+        return this->header_->consume_read_pending();
+    }
 
     void AwaiterRead::await_suspend(std::coroutine_handle<> h) {
         auto c =
@@ -14,13 +16,22 @@ namespace usub::uvent::net::detail {
 
         this->header_->first = c;
         this->header_->clear_busy();
+
+        if (this->header_->consume_read_pending()) {
+            auto resumed = std::exchange(this->header_->first, nullptr);
+            if (resumed) {
+                system::this_thread::detail::q->enqueue(resumed);
+            }
+        }
     }
 
     void AwaiterRead::await_resume() {}
 
     AwaiterWrite::AwaiterWrite(SocketHeader* header) : header_(header) {}
 
-    bool AwaiterWrite::await_ready() { return false; }
+    bool AwaiterWrite::await_ready() {
+        return this->header_->consume_write_pending();
+    }
 
     void AwaiterWrite::await_suspend(std::coroutine_handle<> h) {
         auto c =
@@ -28,13 +39,22 @@ namespace usub::uvent::net::detail {
 
         this->header_->second = c;
         this->header_->clear_busy();
+
+        if (this->header_->consume_write_pending()) {
+            auto resumed = std::exchange(this->header_->second, nullptr);
+            if (resumed) {
+                system::this_thread::detail::q->enqueue(resumed);
+            }
+        }
     }
 
     void AwaiterWrite::await_resume() {}
 
     AwaiterAccept::AwaiterAccept(SocketHeader* header) : header_(header) {}
 
-    bool AwaiterAccept::await_ready() { return false; }
+    bool AwaiterAccept::await_ready() {
+        return this->header_->consume_read_pending();
+    }
 
     void AwaiterAccept::await_suspend(std::coroutine_handle<> h) {
         auto c =
@@ -42,6 +62,13 @@ namespace usub::uvent::net::detail {
 
         this->header_->first = c;
         this->header_->clear_busy();
+
+        if (this->header_->consume_read_pending()) {
+            auto resumed = std::exchange(this->header_->first, nullptr);
+            if (resumed) {
+                system::this_thread::detail::q->enqueue(resumed);
+            }
+        }
     }
 
     void AwaiterAccept::await_resume() {}

--- a/src/net/AwaiterOperations.cpp
+++ b/src/net/AwaiterOperations.cpp
@@ -1,6 +1,5 @@
 #include "uvent/net/AwaiterOperations.h"
 
-#include <cstdio>
 #include "uvent/system/SystemContext.h"
 
 namespace usub::uvent::net::detail {
@@ -8,10 +7,7 @@ namespace usub::uvent::net::detail {
     AwaiterRead::AwaiterRead(SocketHeader* header) : header_(header) {}
 
     bool AwaiterRead::await_ready() {
-        const bool p = this->header_->consume_read_pending();
-        std::fprintf(stderr, "[await_read] await_ready fd=%d pending_was=%d\n", this->header_->fd, (int)p);
-        std::fflush(stderr);
-        return p;
+        return this->header_->consume_read_pending();
     }
 
     void AwaiterRead::await_suspend(std::coroutine_handle<> h) {
@@ -21,10 +17,7 @@ namespace usub::uvent::net::detail {
         this->header_->first = c;
         this->header_->clear_busy();
 
-        const bool p = this->header_->consume_read_pending();
-        std::fprintf(stderr, "[await_read] await_suspend fd=%d post_pending=%d\n", this->header_->fd, (int)p);
-        std::fflush(stderr);
-        if (p) {
+        if (this->header_->consume_read_pending()) {
             auto resumed = std::exchange(this->header_->first, nullptr);
             if (resumed) {
                 system::this_thread::detail::q->enqueue(resumed);

--- a/src/net/AwaiterOperations.cpp
+++ b/src/net/AwaiterOperations.cpp
@@ -1,5 +1,6 @@
 #include "uvent/net/AwaiterOperations.h"
 
+#include <cstdio>
 #include "uvent/system/SystemContext.h"
 
 namespace usub::uvent::net::detail {
@@ -7,7 +8,10 @@ namespace usub::uvent::net::detail {
     AwaiterRead::AwaiterRead(SocketHeader* header) : header_(header) {}
 
     bool AwaiterRead::await_ready() {
-        return this->header_->consume_read_pending();
+        const bool p = this->header_->consume_read_pending();
+        std::fprintf(stderr, "[await_read] await_ready fd=%d pending_was=%d\n", this->header_->fd, (int)p);
+        std::fflush(stderr);
+        return p;
     }
 
     void AwaiterRead::await_suspend(std::coroutine_handle<> h) {
@@ -17,7 +21,10 @@ namespace usub::uvent::net::detail {
         this->header_->first = c;
         this->header_->clear_busy();
 
-        if (this->header_->consume_read_pending()) {
+        const bool p = this->header_->consume_read_pending();
+        std::fprintf(stderr, "[await_read] await_suspend fd=%d post_pending=%d\n", this->header_->fd, (int)p);
+        std::fflush(stderr);
+        if (p) {
             auto resumed = std::exchange(this->header_->first, nullptr);
             if (resumed) {
                 system::this_thread::detail::q->enqueue(resumed);

--- a/src/poll/EPoller.cpp
+++ b/src/poll/EPoller.cpp
@@ -115,23 +115,37 @@ namespace usub::uvent::core
 #ifndef UVENT_ENABLE_REUSEADDR
             sock->try_mark_busy();
 #endif
-            if (event.events & EPOLLIN && sock->first)
+            if (event.events & EPOLLIN)
             {
 #if UVENT_DEBUG
                 spdlog::info("Socket #{} triggered as IN", sock->fd);
 #endif
-                auto c = std::exchange(sock->first, nullptr);
-                system::this_thread::detail::q->enqueue(c);
+                if (sock->first)
+                {
+                    auto c = std::exchange(sock->first, nullptr);
+                    system::this_thread::detail::q->enqueue(c);
+                }
+                else
+                {
+                    sock->mark_read_pending();
+                }
             }
-            if (event.events & EPOLLOUT && sock->second)
+            if (event.events & EPOLLOUT)
             {
 #if UVENT_DEBUG
                 spdlog::info("Socket #{} triggered as OUT", sock->fd);
 #endif
                 if (!(sock->socket_info & static_cast<uint8_t>(net::AdditionalState::CONNECTION_PENDING)))
                 {
-                    auto c = std::exchange(sock->second, nullptr);
-                    system::this_thread::detail::q->enqueue(c);
+                    if (sock->second)
+                    {
+                        auto c = std::exchange(sock->second, nullptr);
+                        system::this_thread::detail::q->enqueue(c);
+                    }
+                    else
+                    {
+                        sock->mark_write_pending();
+                    }
                 }
                 else
                 {
@@ -141,10 +155,14 @@ namespace usub::uvent::core
                     sock->socket_info &= ~static_cast<uint8_t>(net::AdditionalState::CONNECTION_PENDING);
                     if (err != 0)
                         sock->socket_info |= static_cast<uint8_t>(net::AdditionalState::CONNECTION_FAILED);
-                    else
+                    else if (sock->second)
                     {
                         auto c = std::exchange(sock->second, nullptr);
                         system::this_thread::detail::q->enqueue(c);
+                    }
+                    else
+                    {
+                        sock->mark_write_pending();
                     }
                 }
             }

--- a/src/poll/EPoller.cpp
+++ b/src/poll/EPoller.cpp
@@ -4,6 +4,7 @@
 
 #include "uvent/poll/EPoller.h"
 
+#include <cstdio>
 #include "uvent/net/Socket.h"
 #include "uvent/system/Settings.h"
 #include "uvent/system/SystemContext.h"
@@ -25,7 +26,7 @@ namespace usub::uvent::core
         struct epoll_event event{};
         event.data.ptr = reinterpret_cast<void*>(header);
         event.events = 0;
-        event.events = (EPOLLIN | EPOLLOUT | EPOLLET);
+        event.events = (EPOLLIN | EPOLLOUT);
 
 #if UVENT_DEBUG
         spdlog::info("Socket added: fd={} et={} in={} out={}", header->fd, bool(event.events & EPOLLET),
@@ -117,9 +118,8 @@ namespace usub::uvent::core
 #endif
             if (event.events & EPOLLIN)
             {
-#if UVENT_DEBUG
-                spdlog::info("Socket #{} triggered as IN", sock->fd);
-#endif
+                std::fprintf(stderr, "[epoll] fd=%d EPOLLIN first=%p\n", sock->fd, (void*)sock->first.address());
+                std::fflush(stderr);
                 if (sock->first)
                 {
                     auto c = std::exchange(sock->first, nullptr);
@@ -128,6 +128,8 @@ namespace usub::uvent::core
                 else
                 {
                     sock->mark_read_pending();
+                    std::fprintf(stderr, "[epoll] fd=%d marked read_pending\n", sock->fd);
+                    std::fflush(stderr);
                 }
             }
             if (event.events & EPOLLOUT)

--- a/src/poll/EPoller.cpp
+++ b/src/poll/EPoller.cpp
@@ -4,7 +4,6 @@
 
 #include "uvent/poll/EPoller.h"
 
-#include <cstdio>
 #include "uvent/net/Socket.h"
 #include "uvent/system/Settings.h"
 #include "uvent/system/SystemContext.h"
@@ -118,8 +117,9 @@ namespace usub::uvent::core
 #endif
             if (event.events & EPOLLIN)
             {
-                std::fprintf(stderr, "[epoll] fd=%d EPOLLIN first=%p\n", sock->fd, (void*)sock->first.address());
-                std::fflush(stderr);
+#if UVENT_DEBUG
+                spdlog::info("Socket #{} triggered as IN", sock->fd);
+#endif
                 if (sock->first)
                 {
                     auto c = std::exchange(sock->first, nullptr);
@@ -128,8 +128,6 @@ namespace usub::uvent::core
                 else
                 {
                     sock->mark_read_pending();
-                    std::fprintf(stderr, "[epoll] fd=%d marked read_pending\n", sock->fd);
-                    std::fflush(stderr);
                 }
             }
             if (event.events & EPOLLOUT)

--- a/src/system/Thread.cpp
+++ b/src/system/Thread.cpp
@@ -137,6 +137,7 @@ namespace usub::uvent::system
                 auto c_temp =
                     std::coroutine_handle<detail::AwaitableFrameBase>::from_address(this->tmp_coroutines_[i].address());
                 c_temp.destroy();
+                this->tmp_coroutines_[i] = nullptr;
             }
         }
 #ifdef UVENT_ENABLE_REUSEADDR
@@ -179,15 +180,7 @@ namespace usub::uvent::system
         }
     }
 
-    Thread::~Thread()
-    {
-        for (auto& c : this->tmp_coroutines_)
-            if (c)
-                c.destroy();
-        for (auto s : this->tmp_sockets_)
-            if (s)
-                delete s;
-    }
+    Thread::~Thread() {}
 
     void Thread::run_current() { threadFunction(this->stop_source_.get_token()); }
 

--- a/src/system/Thread.cpp
+++ b/src/system/Thread.cpp
@@ -126,6 +126,30 @@ namespace usub::uvent::system
 #endif
             this->processInboxQueue();
         }
+
+        for (;;)
+        {
+            const size_t n_drain = local_q_c.dequeue_bulk(this->tmp_coroutines_.data(), this->tmp_coroutines_.size());
+            if (n_drain == 0)
+                break;
+            for (size_t i = 0; i < n_drain; i++)
+            {
+                auto c_temp =
+                    std::coroutine_handle<detail::AwaitableFrameBase>::from_address(this->tmp_coroutines_[i].address());
+                c_temp.destroy();
+            }
+        }
+#ifdef UVENT_ENABLE_REUSEADDR
+        for (;;)
+        {
+            const size_t n_sockets = local_q_sh.dequeue_bulk(this->tmp_sockets_.data(), this->tmp_sockets_.size());
+            if (n_sockets == 0)
+                break;
+            for (size_t i = 0; i < n_sockets; ++i)
+                delete this->tmp_sockets_[i];
+        }
+#endif
+
 #ifndef UVENT_ENABLE_REUSEADDR
         local_g_qsbr.detach_current_thread();
 #endif
@@ -153,6 +177,16 @@ namespace usub::uvent::system
                     system::this_thread::detail::q->enqueue(buf[i]);
             }
         }
+    }
+
+    Thread::~Thread()
+    {
+        for (auto& c : this->tmp_coroutines_)
+            if (c)
+                c.destroy();
+        for (auto s : this->tmp_sockets_)
+            if (s)
+                delete s;
     }
 
     void Thread::run_current() { threadFunction(this->stop_source_.get_token()); }


### PR DESCRIPTION
Fix EPOLLET event loss and coroutine frame leak at shutdown

This PR fixes two long-standing bugs in the event loop that surface
under load with bursty I/O and consumers that don't drain the kernel
buffer fast enough.

## 1. EPOLLET event loss when no awaiter is registered

### Symptom

Long-running sockets eventually hang. `pg_stat_activity` shows the
backend in `ClientRead` while `ss -tnpi` shows several MB sitting in
the socket's receive queue. The client never reads, the server never
gets NACKed, and the connection idles forever.

### Root cause

`EPoller` registers fds with `EPOLLIN | EPOLLOUT | EPOLLET`. With
edge-triggered semantics, the kernel only re-fires `EPOLLIN` when the
buffer transitions from empty to non-empty. If `EPOLLIN` arrives at a
moment when no coroutine is parked in `sock->first` (for example,
between two awaits where the consumer is briefly busy), the wakeup is
silently dropped. The next `co_await wait_readable()` parks itself and
waits forever, because the kernel will not re-fire until the buffer
drains, which it never does.

### Fix

Two new bits per socket header — `READ_PENDING_MASK` and
`WRITE_PENDING_MASK` — packed into the existing `state` word
(bits 57-58, alongside the unused bits above `TIMEOUT_EPOCH_MASK`).

- `EPoller`: if `EPOLLIN`/`EPOLLOUT` arrives and `sock->first`/`second`
  is null, set the corresponding pending bit instead of discarding
  the event.
- `AwaiterRead`/`AwaiterWrite`/`AwaiterAccept::await_ready`:
  consume the pending bit and proceed without suspending if it was set.
- `AwaiterRead`/`AwaiterWrite`/`AwaiterAccept::await_suspend`:
  after registering into the slot and clearing busy, re-check pending.
  If a wakeup landed in the small window between `await_ready` and the
  store into `first`/`second`, self-resume by enqueueing into the
  ready queue. Closes the race without requiring a full lock.

Files:
- `include/uvent/utils/sync/RefCountedSession.h`
- `include/uvent/net/SocketMetadata.h`
- `src/poll/EPoller.cpp`
- `src/net/AwaiterOperations.cpp`

## 2. Coroutine frame leak at shutdown (~350 MB on a small workload)

### Symptom

ASAN under `-fsanitize=address` reports leaks of `Awaitable<...>` frames
allocated by `pump_input`, `wait_readable`, and similar — over a million
allocations on a workload that only opens 16 connections. Even small
test programs leak hundreds of MB by exit time.

### Root cause

`AwaitableFrame::final_suspend` returns `suspend_always`. After a
coroutine returns, its frame pushes itself into thread-local `q_c`,
the destruction queue. `q_c` is drained inside the main worker loop
(`while (!token.stop_requested())`). When `Uvent::stop()` is called,
the loop exits before processing the last batch of pending destructions.
The frames sitting in `q_c` at exit time are leaked.

### Fix

`Thread::threadFunction`, after the main `while` exits and before the
QSBR detach, drains `q_c` (and `q_sh` under `UVENT_ENABLE_REUSEADDR`)
to empty in a tight loop. Each destroyed handle is overwritten with
`nullptr` in `tmp_coroutines_` to keep the buffer consistent.

Drains live in `threadFunction` rather than `~Thread()` because
thread-local `q_c` is only reachable from inside the worker thread.

Files:
- `src/system/Thread.cpp`

## Testing

- Built with `-fsanitize=address,undefined` and run a workload that
  opens 16 connections, executes ~1M coroutine resumes across 8 large
  exports, and exits via `Uvent::stop()`.
- Before this PR: 354 MB leaked across ~1.08M allocations, plus
  intermittent heap-use-after-free at shutdown.
- After this PR: 0 leaks, no UAF.
- Pre-existing UBSan diagnostics at `Thread.cpp:66` (null `EPoller`
  vptr in early init under REUSEADDR) and `Thread.cpp:80` (null
  `coroutine_handle` write through the bulk-dequeue buffer) are
  unrelated to this PR and left for a separate change.